### PR TITLE
Remove NewsDataHub API references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ ELEVENLABS_API_KEY=your_elevenlabs_api_key
 ELEVENLABS_VOICE_ID=your_voice_id
 SYNC_SO_API_KEY=your_sync_so_api_key
 COHERE_API_KEY=your_cohere_api_key
-NEWS_DATA_HUB_KEY=your_news_data_hub_key
 
 # AWS Configuration
 AWS_ACCESS_KEY_ID=your_aws_access_key

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ An AI-powered pipeline that converts news articles into lip-synced avatar videos
   - Sync.so
   - OpenAI
   - AWS (for S3 storage)
-  - NewsDataHub (for news search)
   - Cohere (for vector storage)
 
 ## Quick Start

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from agents import NewsSearchAgent, NewsAPIClient, NewsDataHubClient
+from agents import NewsSearchAgent, NewsAPIClient
 from NewsVectorStore import NewsVectorStore
 import os
 import json
@@ -45,29 +45,19 @@ def main():
 
     agent = NewsSearchAgent(article_limit=args.limit)
     
-    # Initialize clients
-    newsdatahub_client = NewsDataHubClient()
-    
-    # Check for API keys
-    newsdata_hub_key = os.getenv('NEWS_DATA_HUB_KEY')
-    if not newsdata_hub_key:
-        print("❌ NEWS_DATA_HUB_KEY not found in environment variables.")
+    # Initialize NewsAPI client
+    newsapi_client = NewsAPIClient()
+
+    if not newsapi_client.api_key:
+        print("❌ NEWS_API_KEY not found in environment variables.")
         return
-    
-    # Print partial API key for debugging
-    key_length = len(newsdata_hub_key)
-    masked_key = newsdata_hub_key[:4] + '*' * (key_length - 8) + newsdata_hub_key[-4:] if key_length > 8 else "too_short"
-    print(f"Using NewsDataHub API key: {masked_key}")
-    
-    # Fetch from sources
-    newsdatahub_articles = newsdatahub_client.fetch_ai_news(days_back=7, limit=5)
-    
-    # Combine results
-    all_articles = newsdatahub_articles
+
+    # Fetch from NewsAPI
+    all_articles = newsapi_client.fetch_ai_news(days_back=7, limit=args.limit)
 
     print(f"\nTotal Articles Found: {len(all_articles)}")
     print("\nArticle Sources:")
-    print(f"- NewsDataHub: {len(newsdatahub_articles)}")
+    print(f"- NewsAPI: {len(all_articles)}")
     
     if not all_articles:
         print("\nNo articles found. Please check your API key and try again.")

--- a/models.py
+++ b/models.py
@@ -15,7 +15,7 @@ class NewsArticle(BaseModel):
     link: str
     content: Union[str, ArticleContent] = Field(default='', description="Article content in plain text or structured format")
     source: Optional[str] = None
-    source_type: Literal["newsapi", "google", "linkedin", "newsdatahub"] = Field(..., description="Platform source of the article")
+    source_type: Literal["newsapi", "google", "linkedin"] = Field(..., description="Platform source of the article")
     published_date: Optional[datetime] = None
     engagement: Optional[Dict[str, int]] = Field(default=None, description="Engagement metrics like views, likes")
     author: Optional[str] = None

--- a/process_news_to_video.py
+++ b/process_news_to_video.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Complete pipeline that:
-1. Fetches news articles using NewsDataHub
+1. Fetches news articles using NewsAPI, Google RSS, or Playwright
 2. Generates a script from the first article
 3. Creates audio using ElevenLabs
 4. Produces a lip-synced video with Sync.so
@@ -10,7 +10,7 @@ Complete pipeline that:
 import os
 import json
 import time
-from agents import NewsSearchAgent, NewsAPIClient, NewsDataHubClient
+from agents import NewsSearchAgent, NewsAPIClient
 from content_generator import ContentGenerationAgent, ArticleRequest
 from audio_generator import AudioGenerationAgent, AudioRequest
 from avatar_generator import AvatarGenerationAgent
@@ -22,9 +22,23 @@ def main():
     # Step 1: Fetch news articles
     print("\n📰 Step 1: Fetching news articles...")
     agent = NewsSearchAgent(article_limit=5)
-    newsdata_hub_client = NewsDataHubClient()
-    articles = newsdata_hub_client.fetch_ai_news(days_back=7, limit=5)
-    
+    articles = []
+
+    # Try NewsAPI first if an API key is available
+    newsapi_client = NewsAPIClient()
+    if newsapi_client.api_key:
+        articles = newsapi_client.fetch_ai_news(days_back=7, limit=5)
+
+    # Fallback to RSS feed if NewsAPI fails or returns nothing
+    if not articles:
+        print("⚠️ NewsAPI unavailable. Using Google RSS feed...")
+        articles = agent.fetch_ai_news_from_rss(limit=5)
+
+    # Final fallback to Playwright scraping
+    if not articles:
+        print("⚠️ RSS feed failed. Trying Playwright scraping...")
+        articles = agent.fetch_ai_news_with_playwright(limit=5)
+
     if not articles:
         print("❌ No articles found. Exiting.")
         return

--- a/requirements.txt
+++ b/requirements.txt
@@ -146,3 +146,4 @@ matplotlib>=3.8.0
 pydub>=0.25.1
 s3fs==2025.3.1
 protobuf>=4.25.0,<5.0.0
+feedparser>=6.0.10


### PR DESCRIPTION
## Summary
- remove NewsDataHub client and API key usage
- update article pipeline to fallback to Playwright scraping
- adjust environment template and docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a704457bc8330a709da9dce9c23ef